### PR TITLE
Adding Amazon and Costco to site include list.

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -46,5 +46,7 @@ $("a[href*='1=frontpage']").each((ndx, element) => {
 });
 
 const siteQpIncludes = {
-  "newegg.com": ["Item"]
+  "newegg.com": ["Item"],
+  "amazon.com": ["Item"],
+  "costco.com": ["Item"]
 };


### PR DESCRIPTION
Right now we only look for newegg. We should also look for amazon and costo for deals.